### PR TITLE
Fixed resource tab not working

### DIFF
--- a/app/views/notes/_note_modal.html.erb
+++ b/app/views/notes/_note_modal.html.erb
@@ -1004,25 +1004,5 @@
       document.getElementById(tabName).style.display = "block";
       evt.currentTarget.className += " active";
   }
-
-  function openReference(tab){
-    var i;
-    var x = document.getElementsByClassName('click-reference');
-    var buttons = document.getElementsByClassName('reference-tab-note');
-    for (i = 0; i < x.length; i++) {
-      x[i].style.display = 'none';
-      x[i].style.border = 'thick #FFF solid';
-    }
-    for (i = 0; i < buttons.length; i++) {
-      buttons[i].style.border = 'thin gray solid';
-      buttons[i].style.color = 'gray';
-
-    }
-    document.getElementById(tab).style.display = 'block';
-    document.querySelector(`button[onclick='openReference("${tab}")']`).style.border = 'thin #BC171D solid';
-    document.querySelector(`button[onclick='openReference("${tab}")']`).style.color = '#BC171D';
-
-  }
-  
 </script>
 </div>

--- a/app/views/notes/show.js.erb
+++ b/app/views/notes/show.js.erb
@@ -10,4 +10,23 @@ if (testModal) {
     var modal = new bootstrap.Modal(testModal);
     modal.show();
 }
+
+function openReference(tab){
+    var i;
+    var x = document.getElementsByClassName('click-reference');
+    var buttons = document.getElementsByClassName('reference-tab-note');
+    for (i = 0; i < x.length; i++) {
+        x[i].style.display = 'none';
+        x[i].style.border = 'thick #FFF solid';
+    }
+    for (i = 0; i < buttons.length; i++) {
+        buttons[i].style.border = 'thin gray solid';
+        buttons[i].style.color = 'gray';
+
+    }
+    document.getElementById(tab).style.display = 'block';
+    document.querySelector(`button[onclick='openReference("${tab}")']`).style.border = 'thin #BC171D solid';
+    document.querySelector(`button[onclick='openReference("${tab}")']`).style.color = '#BC171D';
+}
+
 document.getElementById('loader').classList.add('hidden');


### PR DESCRIPTION
##  Investigation
- The cause of the issue was a Reference error to the #openReference function that was used to switch between the resource tabs.  it was due to the function not being accessible when the modal is rendered.

## Changelog :gear: 
- Moved the `#openReference` function to show.js.erb for it to be accessible when being triggerd to clicking the resources tabs.

[Screencast from 2024-09-02 16-02-29.webm](https://github.com/user-attachments/assets/eecfbce4-84b7-45ea-bab8-8819d983afd2)

Please review
